### PR TITLE
fix broken import to Reader

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	// "github.com/observiq/observiq-otel-cli/internal/otlp"
 
 	tea "github.com/charmbracelet/bubbletea"
-	reader "github.com/observiq/bolt-explorer/Reader"
 	"github.com/observiq/bolt-explorer/model"
+	"github.com/observiq/bolt-explorer/reader"
 	"github.com/observiq/bolt-explorer/router"
 	"github.com/observiq/bolt-explorer/style"
 	"go.etcd.io/bbolt"


### PR DESCRIPTION
Hi,
nice project, wanted to try it. But there is a compile error due to a broken/wrong import to `github.com/observiq/bolt-explorer/Reader` in `main.go`.
This PR fixes the import path by setting it to the `Reader` included in the `reader` package.