### PR TITLE
Validate that filepath argument exists and file exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,12 @@ require (
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dlclark/regexp2 v1.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (
@@ -28,6 +31,7 @@ require (
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.15.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/stretchr/testify v1.10.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 go.etcd.io/bbolt v1.3.7 h1:j+zJOnnEjF/kyHlDDgGnVL/AIqIJPq8UoB2GSNfkUfQ=
 go.etcd.io/bbolt v1.3.7/go.mod h1:N9Mkw9X8x5fupy0IKsmuqVtoGDyxsaDlbk4Rd05IAQw=
 go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
@@ -84,3 +86,4 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -1,11 +1,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"os"
-
-	// "github.com/observiq/observiq-otel-cli/fetcher"
-	// "github.com/observiq/observiq-otel-cli/internal/otlp"
 
 	tea "github.com/charmbracelet/bubbletea"
 	reader "github.com/observiq/bolt-explorer/db_reader"
@@ -17,9 +15,9 @@ import (
 
 func main() {
 	// validate first arg is filepath
-	filepath := os.Args[1]
-	if filepath == "" {
-		fmt.Println("No filepath argument provided")
+	filepath, err := getFilepath()
+	if err != nil {
+		fmt.Println(err)
 		os.Exit(1)
 	}
 
@@ -56,4 +54,21 @@ func main() {
 	if err := program.Start(); err != nil {
 		os.Exit(1)
 	}
+}
+
+// getFilepath return the filepath and validates that
+// 1) the first argument exists and
+// 2) the first argument is a file that exists.
+func getFilepath() (string, error) {
+	if len(os.Args) <= 1 {
+		return "", errors.New("filepath argument is required")
+	}
+
+	// validate file path exists
+	filepath := os.Args[1]
+	if _, err := os.Stat(filepath); os.IsNotExist(err) {
+		return "", errors.New("database file does not exist")
+	}
+
+	return filepath, nil
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetFilepath(t *testing.T) {
+	// mock os.Args
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+	os.Args = []string{"bolt-explorer", "testfiles/test.db"}
+
+	filepath, err := getFilepath()
+	require.NoError(t, err)
+	require.Equal(t, "testfiles/test.db", filepath)
+}
+
+func TestGetFilepath_errors(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		errorMsg string
+	}{
+		{name: "no filepath arg", args: []string{}, errorMsg: "filepath argument is required"},
+		{name: "file dne", args: []string{"bolt-explorer", "dne.db"}, errorMsg: "database file does not exist"},
+	}
+
+	originalArgs := os.Args
+	defer func() { os.Args = originalArgs }()
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			os.Args = test.args
+			_, err := getFilepath()
+			require.Error(t, err)
+			require.Contains(t, err.Error(), test.errorMsg)
+		})
+	}
+}


### PR DESCRIPTION
This PR addresses https://github.com/dsvanlani/bolt-explorer/issues/1 by:

1) Creating the `getFilepath` helper method.
2) `getFilepath` returns an error if argument does not exist or file does not exist at that path.